### PR TITLE
Fix youtube failing on videos {short,long}er than a minute

### DIFF
--- a/plugins/youtube.py
+++ b/plugins/youtube.py
@@ -32,8 +32,12 @@ def get_video_description(key,video_id):
         return out
 
     length = data['contentDetails']['duration']
-    timelist = length[2:-1].split('M')
-    seconds = 60*int(timelist[0]) + int(timelist[1])
+    timelist = re.split('[HMS]', length[2:-1])
+    seconds = int(timelist.pop())
+    if timelist:
+        seconds += 60*int(timelist.pop())
+    if timelist:
+        seconds += 60*60*int(timelist.pop())
 
     out += u' - length \x02{}\x02'.format(timeformat.format_time(seconds, simple=True))
 

--- a/plugins/youtube.py
+++ b/plugins/youtube.py
@@ -32,12 +32,15 @@ def get_video_description(key,video_id):
         return out
 
     length = data['contentDetails']['duration']
-    timelist = re.split('[HMS]', length[2:-1])
-    seconds = int(timelist.pop())
-    if timelist:
-        seconds += 60*int(timelist.pop())
-    if timelist:
-        seconds += 60*60*int(timelist.pop())
+    timelist = re.findall('(\d+[DHMS])', length)
+
+    seconds = 0
+    for t in timelist:
+        t_field = int(t[:-1])`
+        if   t[-1:] == 'D': seconds += 86400 * t_field`
+        elif t[-1:] == 'H': seconds += 3600 * t_field`
+        elif t[-1:] == 'M': seconds += 60 * t_field`
+        elif t[-1:] == 'S': seconds += t_field`
 
     out += u' - length \x02{}\x02'.format(timeformat.format_time(seconds, simple=True))
 


### PR DESCRIPTION
YouTube plugin fails on videos longer or shorter than a minute.
I couldn't find any videos longer than 23:59:59, so I think this solution is fine.
The proper way would probably be to import `isodate` and parse it with that, but that'd be another silly dependency.