### PR TITLE
Fix yiff to use channel instead of $channel and other changes.

### DIFF
--- a/plugins/data/yiffs.txt
+++ b/plugins/data/yiffs.txt
@@ -169,7 +169,7 @@ ties up {user} and scrapes her jaguarginer looking for lint and smegma... GOT IT
 touches snoot to nose, licks, sets {user} down o..o
 trails his fingers down {user}'s scaly underside to her sensitive claoca, feeling the heat before dipping his fingers into the moist honeypot
 tries to go down on {user}'s sweet raccoon-gina, but is pushed back by hir throbbing cock
-trips {user}'s hind legs and squishes her sealion snatch against {users}'s semi-hard bison battering ram. {nick} gets hooflammed in the skull and shrieks, then cries, looking at {user} hoping for help!!
+trips {user}'s hind legs and squishes her sealion snatch against {users}'s semi-hard bison battering ram. {nick} gets hooflammed in the skull and shrieks, then cries, looking at {yiffer} hoping for help!!
 tugs and tugs his walleyedong! (_))█████████████████████D ～～～ *   {nick} swims around and gleefully sucks up his own swimmers, fighting off {user} who stops by to investigate and attempts to steal {nick}'s fishshizz!! FUCK OFF BUDDY
 turns around and slides down {user}'s chest, her flat loli nipples rubbing on his tummy as she drops to the ground, turning once more and showing everybody her flat chest
 twirls around {user}'s long llama-neck, planting a kiss on his big slimy mouth

--- a/plugins/data/yiffs.txt
+++ b/plugins/data/yiffs.txt
@@ -1,5 +1,5 @@
 asks if {user} would like to dock and he happily agrees. The two giraffe dongs slosh into each other as the two sexy gorfs make out
-bounces all around {channel}, focusing on {user} and {user}. *PANT PANT* (drags is dingo cock on the ground) "hey guise!! which one of you wants to plow my dirty dog baloon knot??"
+bounces all around {channel}, focusing on {user} and {yiffer}. *PANT PANT* (drags is dingo cock on the ground) "hey guise!! which one of you wants to plow my dirty dog baloon knot??"
 brushes his large zebradong against {user}'s asshole. {user} quickly screams "PUT IN IN ME" and {nick} obeys hir request. Then, {user} becomes jealous and gallops over to face fuck {user}.
 busts a huge creamy yiffload all over {user}
 can't help but fuck the everliving shit out of {user} with a huge foxdick
@@ -8,10 +8,10 @@ caresses {user}'s furry ballsack, inhaling {user}'s sweet musk through his nostr
 clenches his firm, supple buttocks around the throbbing purple head of {user}'s skunkcock
 climbs on top of {user} and roars as she buttfucks the horny lion
 continues swirling her tongue around against {user}'s, as she guides one of his hands down to the waistband of her skirt, pushing the tips of his fingers between her panties and skirt
-creates a disgusting, putrid odor in {channel} causing several users to vomit onto each other, including {user} and {user}. {nick} blushes when she sees what she has caused
+creates a disgusting, putrid odor in {channel} causing several users to vomit onto each other, including {user} and {yiffer}. {nick} blushes when she sees what she has caused
 critches the inside of {user}'s rosebud with his entire hand while lapping up the fountain of badger butter escaping from {user}'s engorged member
 drags a foxy claw across the ridges {user}'s circumcision scar.
-drinks from the pool of thick giraffe jizzum that {user} and {user} have been creating in the corner of {channel}
+drinks from the pool of thick giraffe jizzum that {user} and {yiffer} have been creating in the corner of {channel}
 enflames her smegmated goosepussy, hoping that {user} notices! "Aim for the slightly red stained feathers!" *flap flap*
 engulfs {user}'s wolfcock, relishing the salty taste of the his precum
 exposes his sheath to {user}, while slowly raising his tail as if to invite
@@ -68,13 +68,13 @@ murrs, humping softly against {user}'s hand, twisting the tip of his finger into
 neighs and shudders as his cockhead flares and spews his buttery load, almost choking {user}
 nibbles softly on the carrot potruding from {user}'s juicy hole as {user}'s fluffy bunnytail tickle's his face
 notices {user} is leaking a pink liquid out of his anus and he gallops over to go drink the cloudy butt juice. The strange rectum goo is sweet and tastes like a combonation of strawberries and love
-notices {user} buttfucking {user} while {user} screams. {nick} pulls out his rock hard monster of a gorfdong and uses it shut up {user}. {user} thanks {nick} and continues fucking his prey
+notices {yiffer} buttfucking {user} while {user} screams. {nick} pulls out his rock hard monster of a gorfdong and uses it shut up {user}. {yiffer} thanks {nick} and continues fucking his prey
 opens her legs all the way and faces {user}, giving him a complete view of her pussy
 opens her lips slightly, and probes {user}'s larger lips with her lollipop-sugar-coated tongue
 opens his trap door in the desert floor and scurries over to {user}, trying to get at her succulant scorpion snatch! {user} sees this coming and slams her stinger into the sand, failing to realize that a spider is a small and fast target. {nick} drags {user} out of his trap and throws the web-encrusted prize at {user}, momentarily stunning her!
 pants as {user}'s dripping wet pokeball rests in her hand, and she tosses it to the ground, releasing him as she tries to catch her breath from all the pushing she did
 parts {user}'s buttcheeks and moves his cock into their anus
-peers anxiously at {user}'s encrusted, pulsating wolverine anus... I can't take it any longer, UNLOAD YOUR LOG ON ME BABY!!! {user} can watch!
+peers anxiously at {user}'s encrusted, pulsating wolverine anus... I can't take it any longer, UNLOAD YOUR LOG ON ME BABY!!! {yiffer} can watch!
 picks up {user} and glares at him  "look what you did to me" she says as she puts his head in the gaping hole of her pussy
 picks up {user} out of the puddle, and takes off all of his pee-covered clothes, licking and sucking the pee out of them, swallowing, and saying, "yummmmmy!"
 pokes a finger into {user}'s moist sheath, tasting the tip of his finger in excitement
@@ -98,14 +98,14 @@ puts her hand in {user}'s underwear
 puts her hands on {user}'s crotch and says, "see, it's right here! i can feel it moving around too =D"
 puts his fingers on {user}'s mouth to shush him as he starts working his throbbing foxhood
 puts his muzzle between {user}'s smooth thighs and starts lapping at her slippery clit
-puts on a two-piece bathing suit and opens the door, running past {user} and jumping into {user}'s arms, saying, "look, now i can be almost naked but still have clothes on!" as she places his hand on her bare stomach
+puts on a two-piece bathing suit and opens the door, running past {yiffer} and jumping into {user}'s arms, saying, "look, now i can be almost naked but still have clothes on!" as she places his hand on her bare stomach
 puts {user} in her mouth, licking all over him
 raises her hips a little as {user}'s finger slides into her, causing it to slip in even further into her drenched pussy, and says, "mmmmmm that's really good {user}, keep your finger there"
 raises her tail high, showing {user} her blood engorged claoca from accross the irc channel, hoping to lure him into a mid-chat yiff
 reaches backwards and rubs her hands against {user}'s sides, slipping her hands under his shirt and rubbing along his body
 really wants to blow a load all over {user}'s face but needs time to reload!
 releases his musk all over {user}'s face to try to entice him into digging his tongue deeper into his raccoongina
-ribbits and scales up {user}'s left rear leg and reaches her buffalo cunt. "*ribbit* OH MY GOD it smells like garlic and a bowl of shit, {user}! {nick} exclaims. Being a good sport, {nick} uses his long, slender tongue and attacks {user}'s Buff-V-Jay!! EWW it tastes like smegma!! {user} try this shit!
+ribbits and scales up {user}'s left rear leg and reaches her buffalo cunt. "*ribbit* OH MY GOD it smells like garlic and a bowl of shit, {user}!" {nick} exclaims. Being a good sport, {nick} uses his long, slender tongue and attacks {user}'s Buff-V-Jay!! "EWW it tastes like smegma!! {user} try this shit!"
 rubs against {user}'s large gorf penis causing it to become erect and thick. {nick} winks to {user} which gives her the signal to slam the blood filled sausage into {nick}
 rubs his petite bottom on {user}'s well-endowed raccoon-cock ^_^
 rubs {user}'s footpaws while groping at his crotch with his feet   =^____^=
@@ -115,7 +115,7 @@ rubs the tip of her strapon on {user}'s panties, and giggling at the wet spot fo
 runs her own tongue along {user}'s, tasting her sweet saliva before examining her new cock, running her hands along its length and the pointed head
 runs his fingers along {user}'s soft and slender thighs, running up to his partially erect wolfhood
 runs his fingers through {user}'s silky fur, rubbing his ear to get him excited
-runs over to {user} on top of {user}, pulls down his pants and underwear and chants as she dances around them, "i see your pee pee, i see your pee pee"
+runs over to {user} on top of {yiffer}, pulls down his pants and underwear and chants as she dances around them, "i see your pee pee, i see your pee pee"
 says, "here it comes...!" as the stream of her pee gushes out from below her clit onto {user}'s stomach and waist, dripping all over him and her crotch
 says, "she made me put on this 1 piece" as she stands up in the water, showing {user} her one-piece bathing suit, her flat chest showing her hard nipples sticking out
 screams "Go Go Gadget Penis" and shoots a load all over {user}'s face
@@ -124,13 +124,13 @@ screams in pleasure as he shoots pink jizzum into {user}'s eyes
 shakes her booty at {user} as she says, "hey lookie, i'm only wearing paaanties!"
 shoots his load all over {user}'s face!
 shoves his talons into {user}'s minature penis, making {user} squeel in pain
-shreeks as his foot long cock explodes into {user}'s wet shithole. {user} then rudely makes a mess of {user}'s pots and pans
+shreeks as his foot long cock explodes into {user}'s wet shithole. {nick} then rudely makes a mess of {user}'s pots and pans
 shrugs, and pulls her shirt off over her head, putting {user}'s other hand onto her stomach, and pushing his first hand closer to her hard pink nipples
-sits down and wags his tail, peering up at {user} with puppy eyes... then looks at {user}, and again back to {user}.... {nick} wants something, can you guess what it is? Are you still a K-9 virgin?
+sits down and wags his tail, peering up at {user} with puppy eyes... then looks at {yiffer}, and again back to {user}.... {nick} wants something, can you guess what it is? Are you still a K-9 virgin?
 sits on {user}'s lap, her butt positioned on his crotch
-slams his giraffe meat into {user} whilst being pumped in and out of by {user}, creating a gorf train orgy
+slams his giraffe meat into {user} whilst being pumped in and out of by {yiffer}, creating a gorf train orgy
 slaps {user}'s large penis around a bit
-slides her tongue out, and running it across {user}'s cheek and down onto his neck, asks, "is it OK if {user} joins us?"
+slides her tongue out, and running it across {user}'s cheek and down onto his neck, asks, "is it OK if {yiffer} joins us?"
 slides his lumpy, steamy bear sausage into {user}'s tight butthole. {nick} pumps in and out of the boy pussy until he sprays a thick jizzum into {user}'s colon
 slides his throbbing wolfhood along {user}'s luscious breasts, leaving a trail of precum along her sweat-glistened chest
 slides two fingers into {user}'s tight and firm vagina while fondling hir sheathe
@@ -153,34 +153,33 @@ squeezes {user}'s meaty dragon vent, while giving him a reach-around.
 starts bucking her hips at the same fast rhythm as {user}'s finger rubs inside her, breathing faster and faster until her head starts going numb, her body moving on its own as she moans out, "oooo {user}..!! i'm cum... i..i...aaaAAAHHHH!!"
 starts hurting {user} with a huge fur dildo
 starts to bleed out of his rectum, creating a lube for {user} to use as he mercifully tears apart {nick}'s anus
-strokes her hard, thick whalecock until it bursts all over {user} and his faggot friend {user}
+strokes her hard, thick whalecock until it bursts all over {user} and his faggot friend {yiffer}
 strokes {user}'s flank, nuzzling up to his soft furry neck as they spoon
-sucks the her juices off of {user}'s tongue, licking the inside of his mouth and {user}'s in it
 sucks the pee off of {user}, collecting it all into a large spit ball and splashing it on him, before sucking it off again and gulping it down, spitting out the naked, showered, {user}
-swats down over {user} as he lays on the floor, gently (not hard enough to crush him and still letting him breathe) pressing her butt on him, his head sticking out over her pussy, as she smiles at him and says, "hi =3"
-swims around {channel} trying to get attention. "Hey {user}, have you ever read dolphinsex.org? YOU'RE GONNA NEED IT!!"... {nick} gets gorfed in the blowhole by {user}'s gargantuan frankenfurter from the fatherland! EEK *BAM* EEEK *BAM* EEEK EEK EEEEEK *BAM* *BAM BAM* EEEKEEEKEKEKEEEEEKEEEE!!!!
+squats down over {user} as he lays on the floor, gently (not hard enough to crush him and still letting him breathe) pressing her butt on him, his head sticking out over her pussy, as she smiles at him and says, "hi =3"
+swims around {channel} trying to get attention. "Hey {user}, have you ever read dolphinsex.org? YOU'RE GONNA NEED IT!!"... {user} gets gorfed in the blowhole by {nick}'s gargantuan frankenfurter from the fatherland! EEK *BAM* EEEK *BAM* EEEK EEK EEEEEK *BAM* *BAM BAM* EEEKEEEKEKEKEEEEEKEEEE!!!!
 tailwavies~ at {user}, showing him his engorged, dripping wolfhood
 takes advantage of {user}
 takes a painfully hard grip on {user}'s foxhood from behind and rams his knot right up his virgin tailhole
 takes {user} and ravages them from behind with a huge fox boner.
-takes {user} from {user} and slaps his bare back on her mounds, chanting, "pussy pussy pussy!"
+takes {user} from {yiffer} and slaps his bare back on her mounds, chanting, "pussy pussy pussy!"
 takes {user}'s entire length into his mouth, gagging as he swallows the knot
 takes {user}'s hard rod into his maw and begins suckling like one would their mother's breast   =^____^=
 ties up {user} and scrapes her jaguarginer looking for lint and smegma... GOT IT! {nick} forcefully smears the disgusting musty mess up {user}'s nose, and roars at {user} to keep them the fuck away during the torture session.
 touches snoot to nose, licks, sets {user} down o..o
 trails his fingers down {user}'s scaly underside to her sensitive claoca, feeling the heat before dipping his fingers into the moist honeypot
 tries to go down on {user}'s sweet raccoon-gina, but is pushed back by hir throbbing cock
-trips {user}'s hind legs and squishes her sealion snatch against {user}'s semi-hard bison battering ram. {nick} gets hooflammed in the skull and shrieks, then cries, looking at {user} hoping for help!!
+trips {user}'s hind legs and squishes her sealion snatch against {yiffer}'s semi-hard bison battering ram. {nick} gets hooflammed in the skull and shrieks, then cries, looking at {user} hoping for help!!
 tugs and tugs his walleyedong! (_))█████████████████████D ～～～ *   {nick} swims around and gleefully sucks up his own swimmers, fighting off {user} who stops by to investigate and attempts to steal {nick}'s fishshizz!! FUCK OFF BUDDY
 turns around and slides down {user}'s chest, her flat loli nipples rubbing on his tummy as she drops to the ground, turning once more and showing everybody her flat chest
 twirls around {user}'s long llama-neck, planting a kiss on his big slimy mouth
-utters "mmmhh.... aahhh" into {user}'s ear as she breathes in and out, guiding {user}'s hand farther and farther up onto her chestsadfaces at {user}... baby you know I want to musk you but I can't, I already used it on {nick}!!!
+utters "mmmhh.... aahhh" into {user}'s ear as she breathes in and out, guiding {user}'s hand farther and farther up onto her chest, {nick} sadfaces at {user}... baby you know I want to musk you but I can't, I already used it on {yiffer}!!!
 vigorously tugs his downy-soft feather covered parrot schlong, excitedly bobbing his head up and down trying to get attention from {user}... "SQUAAAK! polly wants a cock, polly wants a cock!!"
 vomits into {user}'s mouth as he ejactulates onto the floor. {user} swallows the half digested pizza rolls and rolls around in the pool of cum
 was about to shoot a load but realized it was only {user} and decided against it
-watches {user} devour {user}'s wolfcock as while touching his own racoon pussy. {nick} then teams up with {user} to spitroast {user}.
+watches {user} devour {yiffer}'s wolfcock as while touching his own racoon pussy. {nick} then teams up with {yiffer} to spitroast {user}.
 wraps his hands around {user}'s back, moving downward while kissing along his soft yet sturdy chest and abs
 writhes in pleasure as {user}'s gazellehood's head flare inside him, massaging his most inner nooks and cranies with each thrust
 writhes with pleasure as {user}'s meaty tapir dick pounds his sensitive turtlehole as {user} nuzzles at hir neck with his snout
-yells to {user} to help him gangbang {user}. {user} agrees to assist {nick} and they happily fuck {user} raw
+yells to {yiffer} to help him gangbang {user}. {yiffer} agrees to assist {nick} and they happily fuck {user} raw
 yiffs all over {user}

--- a/plugins/data/yiffs.txt
+++ b/plugins/data/yiffs.txt
@@ -103,7 +103,7 @@ puts {user} in her mouth, licking all over him
 raises her hips a little as {user}'s finger slides into her, causing it to slip in even further into her drenched pussy, and says, "mmmmmm that's really good {user}, keep your finger there"
 raises her tail high, showing {user} her blood engorged claoca from accross the irc channel, hoping to lure him into a mid-chat yiff
 reaches backwards and rubs her hands against {user}'s sides, slipping her hands under his shirt and rubbing along his body
-really wants to blow a load all over {user}'s face but needs time to reload!    
+really wants to blow a load all over {user}'s face but needs time to reload!
 releases his musk all over {user}'s face to try to entice him into digging his tongue deeper into his raccoongina
 ribbits and scales up {user}'s left rear leg and reaches her buffalo cunt. "*ribbit* OH MY GOD it smells like garlic and a bowl of shit, {user}! {nick} exclaims. Being a good sport, {nick} uses his long, slender tongue and attacks {user}'s Buff-V-Jay!! EWW it tastes like smegma!! {user} try this shit!
 rubs against {user}'s large gorf penis causing it to become erect and thick. {nick} winks to {user} which gives her the signal to slam the blood filled sausage into {nick}
@@ -156,7 +156,7 @@ starts to bleed out of his rectum, creating a lube for {user} to use as he merci
 strokes her hard, thick whalecock until it bursts all over {user} and his faggot friend {user}
 strokes {user}'s flank, nuzzling up to his soft furry neck as they spoon
 sucks the her juices off of {user}'s tongue, licking the inside of his mouth and {user}'s in it
-sucks the pee off of {user}, collecting it all into a large spit ball and splashing it on him, before sucking it off again and gulping it down, spitting out the naked, showered, {user} 
+sucks the pee off of {user}, collecting it all into a large spit ball and splashing it on him, before sucking it off again and gulping it down, spitting out the naked, showered, {user}
 swats down over {user} as he lays on the floor, gently (not hard enough to crush him and still letting him breathe) pressing her butt on him, his head sticking out over her pussy, as she smiles at him and says, "hi =3"
 swims around {channel} trying to get attention. "Hey {user}, have you ever read dolphinsex.org? YOU'RE GONNA NEED IT!!"... {nick} gets gorfed in the blowhole by {user}'s gargantuan frankenfurter from the fatherland! EEK *BAM* EEEK *BAM* EEEK EEK EEEEEK *BAM* *BAM BAM* EEEKEEEKEKEKEEEEEKEEEE!!!!
 tailwavies~ at {user}, showing him his engorged, dripping wolfhood

--- a/plugins/data/yiffs.txt
+++ b/plugins/data/yiffs.txt
@@ -1,5 +1,5 @@
 asks if {user} would like to dock and he happily agrees. The two giraffe dongs slosh into each other as the two sexy gorfs make out
-bounces all around $channel, focusing on {user} and {user}. *PANT PANT* (drags is dingo cock on the ground) "hey guise!! which one of you wants to plow my dirty dog baloon knot\?\?"
+bounces all around {channel}, focusing on {user} and {user}. *PANT PANT* (drags is dingo cock on the ground) "hey guise!! which one of you wants to plow my dirty dog baloon knot??"
 brushes his large zebradong against {user}'s asshole. {user} quickly screams "PUT IN IN ME" and {nick} obeys hir request. Then, {user} becomes jealous and gallops over to face fuck {user}.
 busts a huge creamy yiffload all over {user}
 can't help but fuck the everliving shit out of {user} with a huge foxdick
@@ -8,17 +8,17 @@ caresses {user}'s furry ballsack, inhaling {user}'s sweet musk through his nostr
 clenches his firm, supple buttocks around the throbbing purple head of {user}'s skunkcock
 climbs on top of {user} and roars as she buttfucks the horny lion
 continues swirling her tongue around against {user}'s, as she guides one of his hands down to the waistband of her skirt, pushing the tips of his fingers between her panties and skirt
-creates a disgusting, putrid odor in $channel causing several users to vomit onto each other, including {user} and {user}. {nick} blushes when she sees what she has caused
+creates a disgusting, putrid odor in {channel} causing several users to vomit onto each other, including {user} and {user}. {nick} blushes when she sees what she has caused
 critches the inside of {user}'s rosebud with his entire hand while lapping up the fountain of badger butter escaping from {user}'s engorged member
 drags a foxy claw across the ridges {user}'s circumcision scar.
-drinks from the pool of thick giraffe jizzum that {user} and {user} have been creating in the corner of $channel
+drinks from the pool of thick giraffe jizzum that {user} and {user} have been creating in the corner of {channel}
 enflames her smegmated goosepussy, hoping that {user} notices! "Aim for the slightly red stained feathers!" *flap flap*
 engulfs {user}'s wolfcock, relishing the salty taste of the his precum
 exposes his sheath to {user}, while slowly raising his tail as if to invite
 eyes that splurt of cockjuice with interest, using her tail to then push it firmly up against {user}'s ass, nudging the head against the open ring of flesh.
 feels {user}'s knot throbbing inside him, each pulse unleashing a fire hot load deep in his bowels, sating his lust momentarily
 felt {user}'s lukewarm wolfhood enter him time and time again, making his pussy lips twitch and love juice flow incessantly.
-fills {user} with giraffe juice creating a beautiful roselike odor in $channel
+fills {user} with giraffe juice creating a beautiful roselike odor in {channel}
 flaps his wings wildly as {user} pounds him mercilessly, all while giving his duck dong a firm handshake with his free paw
 gallops gingerly over to {user}'s bed and sits on the corner, showing his fangs in a friendly way. Suddenly {nick} slides his rump down {user}'s bedsheets, leaving a horrible nasty brown streak that smells like musk!!
 gallops over to {user} and attempts to plug his massive gorfdong into her tight gorfgina, but {user} quickly knocks over {nick} with her large, spotted neck and slams her wet giraffe meat into {nick}'s butthole
@@ -56,7 +56,7 @@ lets the last of her pee trickle out of her onto the floor around {user}, before
 licks along {user}'s silky lips, taking {user}'s exposed foxhood and plays with the tip, rubbing the underside with his thumb slowly towards the tip
 licks {user}'s chest at the same place where he poked her and says, "mmmm it sure is nice and warm there" as she plants small kisses on the spot, licking his bare skin
 lifts up pulls down {user}'s pants, showing her panties to {user} and says, "hey {user}, why don't you help {user} out of those naughty panties?"
-looks around $channel for her love... WHERE ARE YOU {user}\?\?\? oh there you are!! {nick} plants a wet donkey kiss on {user}'s furry cock head, fully expecting to get raped in response!!
+looks around {channel} for her love... WHERE ARE YOU {user}??? oh there you are!! {nick} plants a wet donkey kiss on {user}'s furry cock head, fully expecting to get raped in response!!
 looks at {user} and asks, "hey what cup size are your boobies? =D"
 looks at {user} and notices he is covered in pee too
 looks at {user}'s undies in her hand
@@ -142,7 +142,7 @@ slides his throbbing wolfhood along {user}'s luscious breasts, leaving a trail o
 slides two fingers into {user}'s tight and firm vagina while fondling hir sheathe
 slids his rock hard skunk penis into {user}.
 slips his tongue into {user}'s moist sheath, taking in all the flavors of his raccoon musk
-slithers around $channel and targets {user} who seems to be lookin pretty sexy! "Hey tough guy" *exposes his distended rattlesnake anus* "Throw your cockroach cock up there!" *wafts the scent of stale snakejizz and urine at {user} to get his attention*
+slithers around {channel} and targets {user} who seems to be lookin pretty sexy! "Hey tough guy" *exposes his distended rattlesnake anus* "Throw your cockroach cock up there!" *wafts the scent of stale snakejizz and urine at {user} to get his attention*
 slowly glides through the air. {nick} spots {user}, and gets closer. He is a much bigger bird than you thought... human-sized, in fact. {nick} lands by {user}, which is when {user} notices this bird has a huge erect cock... {nick} winks at you, and slams a claw-laden foot onto your back -- You bout to get yiffed, son.
 smiles at {user} and says, "i'm not naked! look, i'm still wearing my shirt! but i'm good, {user} made a big pokeball come out of my pussy =(" she says as she shows him her stretched pussy
 smiles at {user} and slides his hand onto her left breast  "and how about now? can you feel it beating faster?"
@@ -154,7 +154,7 @@ spreads her butt cheeks open, showing {user} her asshole and says, come on, just
 spreads her pussy lips apart  "is it ok in here {user}?"
 spreads the lips of her pussy for {user} to see, "yeah, see right here it's sore when you rub it she says as she points to her clit
 's pussy starts to seep warm lubricant onto {user}
-squawks and chatters at {user} while beating his parrot wings...! {nick} vengefuly claws {user} in the face and then swoops down and gets a painful grip on {user}'s bisonjunk... {user} can't reach {nick} down there!! {nick} pecks lovingly at the jerky meat and bobs his head up and down "POLLY WANT A COCK\?\?\? CAWWW!"
+squawks and chatters at {user} while beating his parrot wings...! {nick} vengefuly claws {user} in the face and then swoops down and gets a painful grip on {user}'s bisonjunk... {user} can't reach {nick} down there!! {nick} pecks lovingly at the jerky meat and bobs his head up and down "POLLY WANT A COCK??? CAWWW!"
 squeezes {user}'s meaty dragon vent, while giving him a reach-around.
 starts bucking her hips at the same fast rhythm as {user}'s finger rubs inside her, breathing faster and faster until her head starts going numb, her body moving on its own as she moans out, "oooo {user}..!! i'm cum... i..i...aaaAAAHHHH!!"
 starts hurting {user} with a huge fur dildo
@@ -164,7 +164,7 @@ strokes {user}'s flank, nuzzling up to his soft furry neck as they spoon
 sucks the her juices off of {user}'s tongue, licking the inside of his mouth and {user}'s in it
 sucks the pee off of {user}, collecting it all into a large spit ball and splashing it on him, before sucking it off again and gulping it down, spitting out the naked, showered, {user} 
 swats down over {user} as he lays on the floor, gently (not hard enough to crush him and still letting him breathe) pressing her butt on him, his head sticking out over her pussy, as she smiles at him and says, "hi =3"
-swims around $channel trying to get attention. "Hey {user}, have you ever read dolphinsex.org? YOU'RE GONNA NEED IT!!"... {nick} gets gorfed in the blowhole by {user}'s gargantuan frankenfurter from the fatherland! EEK *BAM* EEEK *BAM* EEEK EEK EEEEEK *BAM* *BAM BAM* EEEKEEEKEKEKEEEEEKEEEE!!!!
+swims around {channel} trying to get attention. "Hey {user}, have you ever read dolphinsex.org? YOU'RE GONNA NEED IT!!"... {nick} gets gorfed in the blowhole by {user}'s gargantuan frankenfurter from the fatherland! EEK *BAM* EEEK *BAM* EEEK EEK EEEEEK *BAM* *BAM BAM* EEEKEEEKEKEKEEEEEKEEEE!!!!
 tailwavies~ at {user}, showing him his engorged, dripping wolfhood
 takes advantage of {user}
 takes a painfully hard grip on {user}'s foxhood from behind and rams his knot right up his virgin tailhole

--- a/plugins/data/yiffs.txt
+++ b/plugins/data/yiffs.txt
@@ -169,7 +169,7 @@ ties up {user} and scrapes her jaguarginer looking for lint and smegma... GOT IT
 touches snoot to nose, licks, sets {user} down o..o
 trails his fingers down {user}'s scaly underside to her sensitive claoca, feeling the heat before dipping his fingers into the moist honeypot
 tries to go down on {user}'s sweet raccoon-gina, but is pushed back by hir throbbing cock
-trips {user}'s hind legs and squishes her sealion snatch against {yiffer}'s semi-hard bison battering ram. {nick} gets hooflammed in the skull and shrieks, then cries, looking at {user} hoping for help!!
+trips {user}'s hind legs and squishes her sealion snatch against {users}'s semi-hard bison battering ram. {nick} gets hooflammed in the skull and shrieks, then cries, looking at {user} hoping for help!!
 tugs and tugs his walleyedong! (_))█████████████████████D ～～～ *   {nick} swims around and gleefully sucks up his own swimmers, fighting off {user} who stops by to investigate and attempts to steal {nick}'s fishshizz!! FUCK OFF BUDDY
 turns around and slides down {user}'s chest, her flat loli nipples rubbing on his tummy as she drops to the ground, turning once more and showing everybody her flat chest
 twirls around {user}'s long llama-neck, planting a kiss on his big slimy mouth

--- a/plugins/data/yiffs.txt
+++ b/plugins/data/yiffs.txt
@@ -35,12 +35,6 @@ initiates the cuddle pile of Cthulu! Fuzzy tentacles being to lash out and drag 
 inserts a giner into {user}'s raccoon sheef, pumping in and out to create sheefsounds of varying pitches and phonetic properties
 is plundging deep into {user}'s anal cavity, getting fur all over the place
 is puzzled by {user}'s single cock as it's pressed against his chest stomach.
-
-
-
-
-
-
 jumps out of {user}'s packpack and sticks her butt out at {user}, revealing her bare butt cheeks her clenched asshole and pink pussy lips, and waving her tail around at him
 knocks {user} back a few feet with a stream of hot jizzum!
 lactates into a jar and hands it to {user}. {user} quickly becomes jealous of the gift and proceeds to knock the jar out of {user}'s paws and happily slurps up the man milk

--- a/plugins/datafiles.py
+++ b/plugins/datafiles.py
@@ -44,19 +44,19 @@ def get_generator(_json, variables):
     return textgen.TextGenerator(data["templates"], data["parts"], variables=variables)
 
 
-def send_phrase(inp,attack,nick,conn,me,notice):
+def send_phrase(inp,attack,nick,conn,me,notice,chan):
     target = inp.strip()
 
-    if " " in target: 
+    if " " in target:
         notice("Invalid username!")
         return
 
     # if the user is trying to make the bot slap itself, slap them
     if target.lower() == conn.nick.lower() or target.lower() == "itself": target = nick
 
-    values = {"user": target,"nick": conn.nick} #"channel": conn.chan
+    values = {"user": target,"nick": conn.nick, "channel": chan}
     #if inp.split(" ")[-1].isdigit: phrase = attack[int(inp.split(" ")[-1].strip())-1]
-    #else: 
+    #else:
     phrase = random.choice(attack)
     # act out the message
     me(phrase.format(**values).decode('utf-8', "ignore"))
@@ -94,9 +94,9 @@ def flirt(inp, me=None, nick=None, conn=None, notice=None):
 
 
 @hook.command(autohelp=False)
-def yiff(inp, me=None, nick=None, conn=None, notice=None):
+def yiff(inp, me=None, nick=None, conn=None, notice=None, chan=None):
     """yiff <user> -- yiffs <user>."""
-    send_phrase(inp,yiffs,nick,conn,me,notice)
+    send_phrase(inp,yiffs,nick,conn,me,notice, chan)
     return
 
 
@@ -105,7 +105,7 @@ def lewd(inp, me=None, nick=None, conn=None, notice=None):
     """lewd <user> -- lewd <user>."""
     if len(inp) == 0:
         return 'ヽ(◔ ◡ ◔)ノ.･ﾟ*｡･+☆LEWD☆'.decode('UTF-8')
-    else:    
+    else:
         send_phrase(inp,lewds,nick,conn,me,notice)
     return
 
@@ -186,7 +186,7 @@ def get_filename(action,notice):
     elif 'troll' in action: action = 'troll'
     elif 'gain' in action: action = 'gainz'
     elif 'nsfw' in action: action = 'nsfw'
-    else: 
+    else:
         notice('Invalid action')
         return
     return action
@@ -210,7 +210,7 @@ def process_text(inp,name,notice):
     # if not inp or inp is int:
     if 'add' in inp:
         add(inp,name,notice)
-    else:    
+    else:
         with open("plugins/data/{}.txt".format(name)) as file:
             lines = [line.strip() for line in file.readlines() if not line.startswith("//")]
         linecount = len(lines) - 1
@@ -218,7 +218,7 @@ def process_text(inp,name,notice):
         if inp and inp.isdigit(): num = int(inp) - 1
         else: num = randint(0,linecount)
 
-        if num > linecount or num < 0: 
+        if num > linecount or num < 0:
             return "Theres nothing there baka"
 
         reply='\x02[{}/{}]\x02 {}'.format(num+1,linecount+1,lines[num]).decode('utf-8')
@@ -245,7 +245,7 @@ def process_text(inp,name,notice):
 
 #         if action.isdigit(): num = int(action) - 1
 #         elif text.isdigit(): num = int(text) - 1
-        
+
 #         elif 'add' in action:
 #             if 'http:' in text:
 #                 with open('plugins/data/{}.txt'.format(name), 'a') as file:
@@ -253,7 +253,7 @@ def process_text(inp,name,notice):
 #                 notice('{} added.'.format(action))
 #                 file.close()
 #                 return
-#             else: 
+#             else:
 #                 notice('No image to add.')
 #                 return
 #         elif 'del' in action:
@@ -264,14 +264,14 @@ def process_text(inp,name,notice):
 #                 lines = lines.replace(lines[num],'')
 #             print "deleting"
 
-        
+
 #     with open("plugins/data/{}.txt".format(name)) as file:
 #         lines = [line.strip() for line in file.readlines() if not line.startswith("//")]
 #     linecount = len(lines) - 1
 #     if num < 0: num = randint(0,linecount)
 #     reply='\x02[{}/{}]\x02 {}'.format(num+1,linecount+1,lines[num]).decode('utf-8')
 
-    
+
 #     file.close()
 #     lines =[]
 #     return reply
@@ -334,7 +334,7 @@ def bender(inp,say=None):
     say(random.choice(benders))
     benders = []
     return
-    
+
 @hook.command('gains', autohelp=False)
 @hook.command(autohelp=False)
 def gainz(inp, say=None,notice=None):

--- a/plugins/datafiles.py
+++ b/plugins/datafiles.py
@@ -46,7 +46,6 @@ def get_generator(_json, variables):
 
 def send_phrase(inp,attack,nick,conn,me,notice,chan):
     target = inp.strip()
-
     if " " in target:
         notice("Invalid username!")
         return
@@ -54,7 +53,7 @@ def send_phrase(inp,attack,nick,conn,me,notice,chan):
     # if the user is trying to make the bot slap itself, slap them
     if target.lower() == conn.nick.lower() or target.lower() == "itself": target = nick
 
-    values = {"user": target,"nick": conn.nick, "channel": chan}
+    values = {"user": target,"nick": conn.nick, "channel": chan, "yiffer": nick}
     #if inp.split(" ")[-1].isdigit: phrase = attack[int(inp.split(" ")[-1].strip())-1]
     #else:
     phrase = random.choice(attack)


### PR DESCRIPTION
It was annoying me that yiff would say $channel so I wanted to fix it. Also I made some yiffs use the person who initiated the yiff and the person who is getting yiffed, like "uguubot bounces around #uguubot focusing on infinity and infinity" would be "uguubot bounces around #uguubot focusing on infinity and wednesday" if I did the .yiff, it just makes more sense.
P.S
Sorry about all the whitespace getting removed, my editor does it itself. It wouldn't be an issue if the useless whitespace wasn't there in the first place =^)