### PR TITLE
fix videos with 0 dis/likes and enable changes

### DIFF
--- a/plugins/core_admin_channel.py
+++ b/plugins/core_admin_channel.py
@@ -252,7 +252,6 @@ def enable(inp, notice=None, bot=None, chan=None, db=None):
                 if target in " ".join(bot.config["disabled_commands"]):
                     notice(u"[{}]: {} is globally disabled. Use .genable {} to enable.".format(chan,target,target))
                 else:
-                    print "whoops"
                     notice(u"[{}]: {} is not disabled.".format(chan,target))
     return
 

--- a/plugins/core_admin_channel.py
+++ b/plugins/core_admin_channel.py
@@ -237,13 +237,22 @@ def enable(inp, notice=None, bot=None, chan=None, db=None):
     else:
         for target in targets:
             if disabledcommands and target in disabledcommands:
-                disabledcommands = " ".join(disabledcommands.replace(target,'').strip().split())
-                database.set(db,'channels','disabled',disabledcommands,'chan',chan)
-                notice(u"[{}]: {} is now enabled.".format(chan,target))
+                disabledcommands = disabledcommands.split(" ")
+                for commands in disabledcommands:
+                    if target == commands:
+                        disabledcommands = " ".join(disabledcommands)
+                        disabledcommands = " ".join(disabledcommands.replace(target,'').strip().split())
+                        database.set(db,'channels','disabled',disabledcommands,'chan',chan)
+                        notice(u"[{}]: {} is now enabled.".format(chan,target))
+                        return
+                    else:
+                        notice(u"[{}]: {} is not disabled.".format(chan,target))
+                        return
             else:
                 if target in " ".join(bot.config["disabled_commands"]):
                     notice(u"[{}]: {} is globally disabled. Use .genable {} to enable.".format(chan,target,target))
                 else:
+                    print "whoops"
                     notice(u"[{}]: {} is not disabled.".format(chan,target))
     return
 

--- a/plugins/util/web.py
+++ b/plugins/util/web.py
@@ -46,7 +46,7 @@ def haste(text, ext='txt'):
     """ pastes text to a hastebin server """
     page = http.get(paste_url + "/documents", post_data=text)
     data = json.loads(page)
-    return ("%s/%s.%s" % (paste_url, data['key'], ext))
+    return ("%s/raw/%s.%s" % (paste_url, data['key'], ext))
 
 
 def query(query, params={}):

--- a/plugins/youtube.py
+++ b/plugins/youtube.py
@@ -55,7 +55,10 @@ def get_video_description(key,video_id):
     try:
         likes = plural(int(stats['likeCount']), "like")
         dislikes = plural(int(stats['dislikeCount']), "dislike")
-        percent = 100 * float(stats['likeCount'])/(int(stats['likeCount'])+int(stats['dislikeCount']))
+        try:
+            percent = 100 * float(stats['likeCount'])/(int(stats['likeCount'])+int(stats['dislikeCount']))
+        except ZeroDivisionError:
+            percent = 0
     except KeyError:
         likes = 'likes disabled'
         dislikes = 'dislikes disabled'


### PR DESCRIPTION
If you had amazon disabled and you .enable a amazon would have become mzon so this is a quick fix for that, it would be nice if you could only .disable things that are actualy commands too but that is something for some other time. Maybe have a database of commands(including things like interject, not just the shit listed out in .commands) and compare target to the database in .disable or something.